### PR TITLE
typo

### DIFF
--- a/exercises/17-ex-inference-two-props.Rmd
+++ b/exercises/17-ex-inference-two-props.Rmd
@@ -79,7 +79,7 @@ With no currently licensed vaccines to inhibit malaria, good news was welcomed w
     \clearpage
 
 1. **Disaggregating Asian American tobacco use, confidence interval.**
-Based on a study on the degree to which smoking practices differ across ethnic groups. a confidence interval for the difference in current smoking status for Filipino versus Chinese Americans is desired. [@Rao:2021]
+Based on a study on the degree to which smoking practices differ across ethnic groups, a confidence interval for the difference in current smoking status for Filipino versus Chinese Americans is desired. [@Rao:2021]
 
     ```{r}
     library(tidyverse)


### PR DESCRIPTION
Exercise three there is a period that should be a comma. 